### PR TITLE
Convert all sessions

### DIFF
--- a/src/dan_lab_to_nwb/dan_lab_to_nwb_notes.md
+++ b/src/dan_lab_to_nwb/dan_lab_to_nwb_notes.md
@@ -5,6 +5,16 @@
 - Most of the content in Notes.txt and StoreListing.txt appear to be replicated in Info.mat --> ignore in favor of the .mat file
 - Box1-M301sncCalibrationData.mat is useless -- Don't worry about it.
 - Reorganized folders to match expected structure from neo for TDT data.
+- The following sessions do not have video nor fiber photometry and will be excluded from the final dataset, skipping:
+    'M405_M407-250412-081001(done)',
+    'M404_M409-250406-141501(done)',
+    'M404_M409-250405-151801(done)',
+    'M405_M407-250412-142001(done)',
+    'M404-M409-250406-153701 (M404 bad signal, done)',
+    'M405_M407-250413-081001(done)',
+    'M405_M407-250413-152101(done)',
+    'M409_M404-250407-153704 (done)',
+    'M405_M407-250414-081001(done)'
 
 ## LFP
 - LFP channels are both EEG (1,2) and EMG (3,4) automatically filtered (and downsampled?) from TDT

--- a/src/dan_lab_to_nwb/huang_2025_dlc/huang_2025_dlc_convert_all_sessions.py
+++ b/src/dan_lab_to_nwb/huang_2025_dlc/huang_2025_dlc_convert_all_sessions.py
@@ -1,0 +1,165 @@
+"""Primary script to run to convert all sessions in a dataset using session_to_nwb."""
+import shutil
+import traceback
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+from pprint import pformat
+from typing import Union
+
+from pydantic import DirectoryPath
+from pymatreader import read_mat
+from tqdm import tqdm
+
+from dan_lab_to_nwb.huang_2025_dlc.huang_2025_dlc_convert_session import session_to_nwb
+
+
+def dataset_to_nwb(
+    *,
+    data_dir_path: DirectoryPath,
+    output_dir_path: DirectoryPath,
+    max_workers: int = 1,
+    verbose: bool = True,
+):
+    """Convert the entire dataset to NWB.
+
+    Parameters
+    ----------
+    data_dir_path : DirectoryPath
+        The path to the directory containing the raw data.
+    output_dir_path : DirectoryPath
+        The path to the directory where the NWB files will be saved.
+    max_workers : int, optional
+        The number of workers to use for parallel processing, by default 1
+    verbose : bool, optional
+        Whether to print verbose output, by default True
+    """
+    data_dir_path = Path(data_dir_path)
+    session_to_nwb_kwargs_per_session = get_session_to_nwb_kwargs_per_session(
+        data_dir_path=data_dir_path,
+    )
+
+    futures = []
+    with ProcessPoolExecutor(max_workers=max_workers) as executor:
+        for session_to_nwb_kwargs in session_to_nwb_kwargs_per_session:
+            session_to_nwb_kwargs["output_dir_path"] = output_dir_path
+            session_to_nwb_kwargs["verbose"] = verbose
+            nwbfile_name = get_nwbfile_name(session_to_nwb_kwargs=session_to_nwb_kwargs)
+            nwbfile_stem = Path(nwbfile_name).stem
+            exception_file_path = output_dir_path / f"ERROR_{nwbfile_stem}.txt"
+            futures.append(
+                executor.submit(
+                    safe_session_to_nwb,
+                    session_to_nwb_kwargs=session_to_nwb_kwargs,
+                    exception_file_path=exception_file_path,
+                )
+            )
+        for _ in tqdm(as_completed(futures), total=len(futures)):
+            pass
+
+
+def safe_session_to_nwb(*, session_to_nwb_kwargs: dict, exception_file_path: Union[Path, str]):
+    """Convert a session to NWB while handling any errors by recording error messages to the exception_file_path.
+
+    Parameters
+    ----------
+    session_to_nwb_kwargs : dict
+        The arguments for session_to_nwb.
+    exception_file_path : Path
+        The path to the file where the exception messages will be saved.
+    """
+    exception_file_path = Path(exception_file_path)
+    try:
+        session_to_nwb(**session_to_nwb_kwargs)
+    except Exception as e:
+        with open(exception_file_path, mode="w") as f:
+            f.write(f"session_to_nwb_kwargs: \n {pformat(session_to_nwb_kwargs)}\n\n")
+            f.write(traceback.format_exc())
+
+
+def get_nwbfile_name(*, session_to_nwb_kwargs: dict) -> str:
+    """Get the NWB file name based on the session_to_nwb_kwargs.
+
+    Parameters
+    ----------
+    session_to_nwb_kwargs : dict
+        The kwargs for session_to_nwb, which should contain the path to the info file.
+
+    Returns
+    -------
+    str
+        The NWB file name.
+    """
+    info_file_path = session_to_nwb_kwargs["info_file_path"]
+    info = read_mat(filename=info_file_path)["Info"]
+    session_id = info["blockname"]
+    subject_id = info["Subject"]
+    nwbfile_name = f"sub-{subject_id}_ses-{session_id}.nwb"
+    return nwbfile_name
+
+
+def get_session_to_nwb_kwargs_per_session(
+    *,
+    data_dir_path: DirectoryPath,
+):
+    """Get the kwargs for session_to_nwb for each session in the dataset.
+
+    Parameters
+    ----------
+    data_dir_path : DirectoryPath
+        The path to the directory containing the raw data.
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        A list of dictionaries containing the kwargs for session_to_nwb for each session.
+    """
+
+    data_dir_path = Path(data_dir_path)
+    session_to_nwb_kwargs_per_session = []
+    for subject_folder in data_dir_path.iterdir():
+        if not subject_folder.is_dir():
+            continue
+        behavioral_summary_file_path = subject_folder / f"{subject_folder.name}_beh_summary.csv"
+        for session_folder in subject_folder.iterdir():
+            if not session_folder.is_dir():
+                continue
+            check_FP_folder = session_folder / "check_FP"
+            info_file_path = check_FP_folder / "Info.mat"
+            video_file_path = next(session_folder.glob("*.avi"))
+            dlc_file_path = next(session_folder.glob("*DLC*.h5"))
+            labels_file_path = check_FP_folder / "labels.mat"
+            eeg_file_path = check_FP_folder / "EEG.mat"
+            emg_file_path = check_FP_folder / "EMG.mat"
+            fs_file_path = check_FP_folder / "SampFreq.mat"
+            session_to_nwb_kwargs = dict(
+                info_file_path=info_file_path,
+                video_file_path=video_file_path,
+                dlc_file_path=dlc_file_path,
+                labels_file_path=labels_file_path,
+                behavioral_summary_file_path=behavioral_summary_file_path,
+                eeg_file_path=eeg_file_path,
+                emg_file_path=emg_file_path,
+                fs_file_path=fs_file_path,
+            )
+            session_to_nwb_kwargs_per_session.append(session_to_nwb_kwargs)
+
+    return session_to_nwb_kwargs_per_session
+
+
+if __name__ == "__main__":
+
+    # Parameters for conversion
+    data_dir_path = Path("/Volumes/T7/CatalystNeuro/Dan/Test - video analysis")
+    output_dir_path = Path("/Volumes/T7/CatalystNeuro/Dan/conversion_nwb/huang_2025_dlc")
+    max_workers = 4
+    verbose = False
+
+    if output_dir_path.exists():
+        shutil.rmtree(output_dir_path)
+
+    dataset_to_nwb(
+        data_dir_path=data_dir_path,
+        output_dir_path=output_dir_path,
+        max_workers=max_workers,
+        verbose=verbose,
+    )

--- a/src/dan_lab_to_nwb/huang_2025_tdt/huang_2025_tdt_convert_all_sessions.py
+++ b/src/dan_lab_to_nwb/huang_2025_tdt/huang_2025_tdt_convert_all_sessions.py
@@ -112,6 +112,18 @@ def get_session_to_nwb_kwargs_per_session(
     list[dict[str, Any]]
         A list of dictionaries containing the kwargs for session_to_nwb for each session.
     """
+    sessions_to_skip = [
+        "M405_M407-250412-081001(done)",
+        "M404_M409-250406-141501(done)",
+        "M404_M409-250405-151801(done)",
+        "M405_M407-250412-142001(done)",
+        "M404-M409-250406-153701 (M404 bad signal, done)",
+        "M405_M407-250413-081001(done)",
+        "M405_M407-250413-152101(done)",
+        "M409_M404-250407-153704 (done)",
+        "M405_M407-250414-081001(done)",
+    ]
+
     data_dir_path = Path(data_dir_path)
     session_to_nwb_kwargs_per_session = []
     dataset_folder_names = [
@@ -124,6 +136,8 @@ def get_session_to_nwb_kwargs_per_session(
         for outer_session_folder in dataset_folder.iterdir():
             if not outer_session_folder.is_dir():
                 continue
+            if outer_session_folder.name in sessions_to_skip:
+                continue
             for session_folder in outer_session_folder.iterdir():
                 if not session_folder.is_dir():
                     continue
@@ -131,11 +145,7 @@ def get_session_to_nwb_kwargs_per_session(
                     if not segment_folder.is_dir():
                         continue
                     info_file_path = segment_folder / "Info.mat"
-                    try:
-                        video_file_path = next(segment_folder.glob("*.avi"))
-                    except StopIteration:
-                        print(f"No .avi file found in {segment_folder}")
-                        continue
+                    video_file_path = next(segment_folder.glob("*.avi"))
                     tdt_fp_folder_path = segment_folder
                     tdt_ephys_folder_path = session_folder
                     session_to_nwb_kwargs = dict(

--- a/src/dan_lab_to_nwb/huang_2025_tdt/huang_2025_tdt_convert_all_sessions.py
+++ b/src/dan_lab_to_nwb/huang_2025_tdt/huang_2025_tdt_convert_all_sessions.py
@@ -114,42 +114,34 @@ def get_session_to_nwb_kwargs_per_session(
     """
     data_dir_path = Path(data_dir_path)
     session_to_nwb_kwargs_per_session = []
-
-    # Example Session with "pTra_con" type optogenetics
-    info_file_path = data_dir_path / "Lindsay_SBO_op1-E_2in1_pTra_con-241101-072001" / "M301-241108-072001" / "Info.mat"
-    video_file_path = (
-        data_dir_path
-        / "Lindsay_SBO_op1-E_2in1_pTra_con-241101-072001"
-        / "M301-241108-072001"
-        / "Lindsay_SBO_op1-E_2in1_pTra_con-241101-072001_M301-241108-072001_Cam1.avi"
-    )
-    tdt_fp_folder_path = data_dir_path / "Lindsay_SBO_op1-E_2in1_pTra_con-241101-072001" / "M301-241108-072001"
-    tdt_ephys_folder_path = data_dir_path / "Lindsay_SBO_op1-E_2in1_pTra_con-241101-072001"
-    session_to_nwb_kwargs = dict(
-        info_file_path=info_file_path,
-        video_file_path=video_file_path,
-        tdt_fp_folder_path=tdt_fp_folder_path,
-        tdt_ephys_folder_path=tdt_ephys_folder_path,
-    )
-    session_to_nwb_kwargs_per_session.append(session_to_nwb_kwargs)
-
-    # Example Session with "opto" type optogenetics
-    info_file_path = data_dir_path / "Lindsay_SBO_opto1-Evoke12_2in1-240914-155559" / "M301-240917-163001" / "Info.mat"
-    video_file_path = (
-        data_dir_path
-        / "Lindsay_SBO_opto1-Evoke12_2in1-240914-155559"
-        / "M301-240917-163001"
-        / "Lindsay_SBO_opto1-Evoke12_2in1-240914-155559_M301-240917-163001_Cam1.avi"
-    )
-    tdt_fp_folder_path = data_dir_path / "Lindsay_SBO_opto1-Evoke12_2in1-240914-155559" / "M301-240917-163001"
-    tdt_ephys_folder_path = data_dir_path / "Lindsay_SBO_opto1-Evoke12_2in1-240914-155559"
-    session_to_nwb_kwargs = dict(
-        info_file_path=info_file_path,
-        video_file_path=video_file_path,
-        tdt_fp_folder_path=tdt_fp_folder_path,
-        tdt_ephys_folder_path=tdt_ephys_folder_path,
-    )
-    session_to_nwb_kwargs_per_session.append(session_to_nwb_kwargs)
+    dataset_folder_names = [
+        "Bing-202504",
+        "WS8-202504",
+        "ExampleSessions",
+    ]
+    for folder_name in dataset_folder_names:
+        dataset_folder = data_dir_path / folder_name
+        for session_folder in dataset_folder.iterdir():
+            if not session_folder.is_dir():
+                continue
+            for segment_folder in session_folder.iterdir():
+                if not segment_folder.is_dir():
+                    continue
+                info_file_path = segment_folder / "Info.mat"
+                try:
+                    video_file_path = next(segment_folder.glob("*.avi"))
+                except StopIteration:
+                    print(f"No .avi file found in {segment_folder}")
+                    continue
+                tdt_fp_folder_path = segment_folder
+                tdt_ephys_folder_path = session_folder
+                session_to_nwb_kwargs = dict(
+                    info_file_path=info_file_path,
+                    video_file_path=video_file_path,
+                    tdt_fp_folder_path=tdt_fp_folder_path,
+                    tdt_ephys_folder_path=tdt_ephys_folder_path,
+                )
+                session_to_nwb_kwargs_per_session.append(session_to_nwb_kwargs)
 
     return session_to_nwb_kwargs_per_session
 

--- a/src/dan_lab_to_nwb/huang_2025_tdt/huang_2025_tdt_convert_all_sessions.py
+++ b/src/dan_lab_to_nwb/huang_2025_tdt/huang_2025_tdt_convert_all_sessions.py
@@ -44,7 +44,8 @@ def dataset_to_nwb(
             session_to_nwb_kwargs["output_dir_path"] = output_dir_path
             session_to_nwb_kwargs["verbose"] = verbose
             nwbfile_name = get_nwbfile_name(session_to_nwb_kwargs=session_to_nwb_kwargs)
-            exception_file_path = output_dir_path / f"ERROR_{nwbfile_name}.txt"
+            nwbfile_stem = Path(nwbfile_name).stem
+            exception_file_path = output_dir_path / f"ERROR_{nwbfile_stem}.txt"
             futures.append(
                 executor.submit(
                     safe_session_to_nwb,

--- a/src/dan_lab_to_nwb/huang_2025_tdt/huang_2025_tdt_convert_all_sessions.py
+++ b/src/dan_lab_to_nwb/huang_2025_tdt/huang_2025_tdt_convert_all_sessions.py
@@ -121,27 +121,30 @@ def get_session_to_nwb_kwargs_per_session(
     ]
     for folder_name in dataset_folder_names:
         dataset_folder = data_dir_path / folder_name
-        for session_folder in dataset_folder.iterdir():
-            if not session_folder.is_dir():
+        for outer_session_folder in dataset_folder.iterdir():
+            if not outer_session_folder.is_dir():
                 continue
-            for segment_folder in session_folder.iterdir():
-                if not segment_folder.is_dir():
+            for session_folder in outer_session_folder.iterdir():
+                if not session_folder.is_dir():
                     continue
-                info_file_path = segment_folder / "Info.mat"
-                try:
-                    video_file_path = next(segment_folder.glob("*.avi"))
-                except StopIteration:
-                    print(f"No .avi file found in {segment_folder}")
-                    continue
-                tdt_fp_folder_path = segment_folder
-                tdt_ephys_folder_path = session_folder
-                session_to_nwb_kwargs = dict(
-                    info_file_path=info_file_path,
-                    video_file_path=video_file_path,
-                    tdt_fp_folder_path=tdt_fp_folder_path,
-                    tdt_ephys_folder_path=tdt_ephys_folder_path,
-                )
-                session_to_nwb_kwargs_per_session.append(session_to_nwb_kwargs)
+                for segment_folder in session_folder.iterdir():
+                    if not segment_folder.is_dir():
+                        continue
+                    info_file_path = segment_folder / "Info.mat"
+                    try:
+                        video_file_path = next(segment_folder.glob("*.avi"))
+                    except StopIteration:
+                        print(f"No .avi file found in {segment_folder}")
+                        continue
+                    tdt_fp_folder_path = segment_folder
+                    tdt_ephys_folder_path = session_folder
+                    session_to_nwb_kwargs = dict(
+                        info_file_path=info_file_path,
+                        video_file_path=video_file_path,
+                        tdt_fp_folder_path=tdt_fp_folder_path,
+                        tdt_ephys_folder_path=tdt_ephys_folder_path,
+                    )
+                    session_to_nwb_kwargs_per_session.append(session_to_nwb_kwargs)
 
     return session_to_nwb_kwargs_per_session
 

--- a/src/dan_lab_to_nwb/huang_2025_tdt/huang_2025_tdt_convert_session.py
+++ b/src/dan_lab_to_nwb/huang_2025_tdt/huang_2025_tdt_convert_session.py
@@ -80,7 +80,7 @@ def session_to_nwb(
 
 def main():
     # Parameters for conversion
-    data_dir_path = Path("/Volumes/T7/CatalystNeuro/Dan/Test - TDT data/ExampleSessions")
+    data_dir_path = Path("/Volumes/T7/CatalystNeuro/Dan/Test - TDT data")
     output_dir_path = Path("/Volumes/T7/CatalystNeuro/Dan/conversion_nwb/huang_2025_tdt")
     stub_test = True
 
@@ -90,6 +90,7 @@ def main():
     # Example Session with "pTra_con" type optogenetics
     info_file_path = (
         data_dir_path
+        / "ExampleSessions"
         / "M301-241108-072001"
         / "Lindsay_SBO_op1-E_2in1_pTra_con-241101-072001"
         / "M301-241108-072001"
@@ -97,15 +98,22 @@ def main():
     )
     video_file_path = (
         data_dir_path
+        / "ExampleSessions"
         / "M301-241108-072001"
         / "Lindsay_SBO_op1-E_2in1_pTra_con-241101-072001"
         / "M301-241108-072001"
         / "Lindsay_SBO_op1-E_2in1_pTra_con-241101-072001_M301-241108-072001_Cam1.avi"
     )
     tdt_fp_folder_path = (
-        data_dir_path / "M301-241108-072001" / "Lindsay_SBO_op1-E_2in1_pTra_con-241101-072001" / "M301-241108-072001"
+        data_dir_path
+        / "ExampleSessions"
+        / "M301-241108-072001"
+        / "Lindsay_SBO_op1-E_2in1_pTra_con-241101-072001"
+        / "M301-241108-072001"
     )
-    tdt_ephys_folder_path = data_dir_path / "M301-241108-072001" / "Lindsay_SBO_op1-E_2in1_pTra_con-241101-072001"
+    tdt_ephys_folder_path = (
+        data_dir_path / "ExampleSessions" / "M301-241108-072001" / "Lindsay_SBO_op1-E_2in1_pTra_con-241101-072001"
+    )
     session_to_nwb(
         info_file_path=info_file_path,
         video_file_path=video_file_path,
@@ -118,6 +126,7 @@ def main():
     # Example Session with "opto" type optogenetics
     info_file_path = (
         data_dir_path
+        / "ExampleSessions"
         / "M301-240917-163001"
         / "Lindsay_SBO_opto1-Evoke12_2in1-240914-155559"
         / "M301-240917-163001"
@@ -125,15 +134,94 @@ def main():
     )
     video_file_path = (
         data_dir_path
+        / "ExampleSessions"
         / "M301-240917-163001"
         / "Lindsay_SBO_opto1-Evoke12_2in1-240914-155559"
         / "M301-240917-163001"
         / "Lindsay_SBO_opto1-Evoke12_2in1-240914-155559_M301-240917-163001_Cam1.avi"
     )
     tdt_fp_folder_path = (
-        data_dir_path / "M301-240917-163001" / "Lindsay_SBO_opto1-Evoke12_2in1-240914-155559" / "M301-240917-163001"
+        data_dir_path
+        / "ExampleSessions"
+        / "M301-240917-163001"
+        / "Lindsay_SBO_opto1-Evoke12_2in1-240914-155559"
+        / "M301-240917-163001"
     )
-    tdt_ephys_folder_path = data_dir_path / "M301-240917-163001" / "Lindsay_SBO_opto1-Evoke12_2in1-240914-155559"
+    tdt_ephys_folder_path = (
+        data_dir_path / "ExampleSessions" / "M301-240917-163001" / "Lindsay_SBO_opto1-Evoke12_2in1-240914-155559"
+    )
+    session_to_nwb(
+        info_file_path=info_file_path,
+        video_file_path=video_file_path,
+        tdt_fp_folder_path=tdt_fp_folder_path,
+        tdt_ephys_folder_path=tdt_ephys_folder_path,
+        output_dir_path=output_dir_path,
+        stub_test=stub_test,
+    )
+
+    # Example Session with "SBOX_R" type optogenetics
+    info_file_path = (
+        data_dir_path
+        / "WS8-202504"
+        / "M315-250417-082001"
+        / "Lindsay_SBOX_R_evoke_2in1-250416-184040"
+        / "M315-250417-082001"
+        / "Info.mat"
+    )
+    video_file_path = (
+        data_dir_path
+        / "WS8-202504"
+        / "M315-250417-082001"
+        / "Lindsay_SBOX_R_evoke_2in1-250416-184040"
+        / "M315-250417-082001"
+        / "Lindsay_SBOX_R_evoke_2in1-250416-184040_M315-250417-082001_Cam1.avi"
+    )
+    tdt_fp_folder_path = (
+        data_dir_path
+        / "WS8-202504"
+        / "M315-250417-082001"
+        / "Lindsay_SBOX_R_evoke_2in1-250416-184040"
+        / "M315-250417-082001"
+    )
+    tdt_ephys_folder_path = (
+        data_dir_path / "WS8-202504" / "M315-250417-082001" / "Lindsay_SBOX_R_evoke_2in1-250416-184040"
+    )
+    session_to_nwb(
+        info_file_path=info_file_path,
+        video_file_path=video_file_path,
+        tdt_fp_folder_path=tdt_fp_folder_path,
+        tdt_ephys_folder_path=tdt_ephys_folder_path,
+        output_dir_path=output_dir_path,
+        stub_test=stub_test,
+    )
+
+    # Example Session with "TDTb_R" type optogenetics
+    info_file_path = (
+        data_dir_path
+        / "Bing-202504"
+        / "M412-250421-072001"
+        / "Lindsay_TDTb_R_evoke_2in1-250421-000320"
+        / "M412-250421-072001"
+        / "Info.mat"
+    )
+    video_file_path = (
+        data_dir_path
+        / "Bing-202504"
+        / "M412-250421-072001"
+        / "Lindsay_TDTb_R_evoke_2in1-250421-000320"
+        / "M412-250421-072001"
+        / "Lindsay_TDTb_R_evoke_2in1-250421-000320_M412-250421-072001_Cam1.avi"
+    )
+    tdt_fp_folder_path = (
+        data_dir_path
+        / "Bing-202504"
+        / "M412-250421-072001"
+        / "Lindsay_TDTb_R_evoke_2in1-250421-000320"
+        / "M412-250421-072001"
+    )
+    tdt_ephys_folder_path = (
+        data_dir_path / "Bing-202504" / "M412-250421-072001" / "Lindsay_TDTb_R_evoke_2in1-250421-000320"
+    )
     session_to_nwb(
         info_file_path=info_file_path,
         video_file_path=video_file_path,

--- a/src/dan_lab_to_nwb/huang_2025_tdt/huang_2025_tdt_convert_session.py
+++ b/src/dan_lab_to_nwb/huang_2025_tdt/huang_2025_tdt_convert_session.py
@@ -80,7 +80,7 @@ def session_to_nwb(
 
 def main():
     # Parameters for conversion
-    data_dir_path = Path("/Volumes/T7/CatalystNeuro/Dan/Test - TDT data")
+    data_dir_path = Path("/Volumes/T7/CatalystNeuro/Dan/Test - TDT data/ExampleSessions")
     output_dir_path = Path("/Volumes/T7/CatalystNeuro/Dan/conversion_nwb/huang_2025_tdt")
     stub_test = True
 

--- a/src/dan_lab_to_nwb/huang_2025_tdt/huang_2025_tdt_convert_session.py
+++ b/src/dan_lab_to_nwb/huang_2025_tdt/huang_2025_tdt_convert_session.py
@@ -88,15 +88,24 @@ def main():
         shutil.rmtree(output_dir_path)
 
     # Example Session with "pTra_con" type optogenetics
-    info_file_path = data_dir_path / "Lindsay_SBO_op1-E_2in1_pTra_con-241101-072001" / "M301-241108-072001" / "Info.mat"
+    info_file_path = (
+        data_dir_path
+        / "M301-241108-072001"
+        / "Lindsay_SBO_op1-E_2in1_pTra_con-241101-072001"
+        / "M301-241108-072001"
+        / "Info.mat"
+    )
     video_file_path = (
         data_dir_path
+        / "M301-241108-072001"
         / "Lindsay_SBO_op1-E_2in1_pTra_con-241101-072001"
         / "M301-241108-072001"
         / "Lindsay_SBO_op1-E_2in1_pTra_con-241101-072001_M301-241108-072001_Cam1.avi"
     )
-    tdt_fp_folder_path = data_dir_path / "Lindsay_SBO_op1-E_2in1_pTra_con-241101-072001" / "M301-241108-072001"
-    tdt_ephys_folder_path = data_dir_path / "Lindsay_SBO_op1-E_2in1_pTra_con-241101-072001"
+    tdt_fp_folder_path = (
+        data_dir_path / "M301-241108-072001" / "Lindsay_SBO_op1-E_2in1_pTra_con-241101-072001" / "M301-241108-072001"
+    )
+    tdt_ephys_folder_path = data_dir_path / "M301-241108-072001" / "Lindsay_SBO_op1-E_2in1_pTra_con-241101-072001"
     session_to_nwb(
         info_file_path=info_file_path,
         video_file_path=video_file_path,
@@ -107,15 +116,24 @@ def main():
     )
 
     # Example Session with "opto" type optogenetics
-    info_file_path = data_dir_path / "Lindsay_SBO_opto1-Evoke12_2in1-240914-155559" / "M301-240917-163001" / "Info.mat"
+    info_file_path = (
+        data_dir_path
+        / "M301-240917-163001"
+        / "Lindsay_SBO_opto1-Evoke12_2in1-240914-155559"
+        / "M301-240917-163001"
+        / "Info.mat"
+    )
     video_file_path = (
         data_dir_path
+        / "M301-240917-163001"
         / "Lindsay_SBO_opto1-Evoke12_2in1-240914-155559"
         / "M301-240917-163001"
         / "Lindsay_SBO_opto1-Evoke12_2in1-240914-155559_M301-240917-163001_Cam1.avi"
     )
-    tdt_fp_folder_path = data_dir_path / "Lindsay_SBO_opto1-Evoke12_2in1-240914-155559" / "M301-240917-163001"
-    tdt_ephys_folder_path = data_dir_path / "Lindsay_SBO_opto1-Evoke12_2in1-240914-155559"
+    tdt_fp_folder_path = (
+        data_dir_path / "M301-240917-163001" / "Lindsay_SBO_opto1-Evoke12_2in1-240914-155559" / "M301-240917-163001"
+    )
+    tdt_ephys_folder_path = data_dir_path / "M301-240917-163001" / "Lindsay_SBO_opto1-Evoke12_2in1-240914-155559"
     session_to_nwb(
         info_file_path=info_file_path,
         video_file_path=video_file_path,

--- a/src/dan_lab_to_nwb/huang_2025_tdt/huang_2025_tdt_optogenetic_interface.py
+++ b/src/dan_lab_to_nwb/huang_2025_tdt/huang_2025_tdt_optogenetic_interface.py
@@ -34,10 +34,18 @@ class Huang2025OptogeneticInterface(BaseDataInterface):
                 "optogenetic_series_PFC_test_pulse": "St2_",
                 "optogenetic_series_VTA_intense_stimulation": "LasT",
             },
+            "SBOX_R_evoke_2in1": {
+                "optogenetic_series_VTA_test_pulse": "St1_",
+                "optogenetic_series_PFC_test_pulse": "St2_",
+            },
+            "TDTb_R_evoke_2in1": {
+                "optogenetic_series_VTA_test_pulse": "St1_",
+                "optogenetic_series_PFC_test_pulse": "St2_",
+            },
         }
         for file_pattern, series_name_to_epoc_name in file_pattern_to_series_name_to_epoc_name.items():
             if file_pattern in folder_path.parent.name:
-                return series_name_to_epoc_name[series_name]
+                return series_name_to_epoc_name.get(series_name)
         raise ValueError(
             f"No matching file pattern found in {folder_path.parent}. Expected one of: {list(file_pattern_to_series_name_to_epoc_name.keys())}"
         )
@@ -51,6 +59,8 @@ class Huang2025OptogeneticInterface(BaseDataInterface):
         for series_metadata in opto_metadata["OptogeneticSeries"]:
             series_name = series_metadata["name"]
             epoc_name = self.get_epoc_name(series_name=series_name)
+            if epoc_name is None:
+                continue
             onset_times = tdt_photometry.epocs[epoc_name].onset
             offset_times = tdt_photometry.epocs[epoc_name].offset
             power = series_metadata["power"]

--- a/src/dan_lab_to_nwb/huang_2025_tdt/reorganize_data.py
+++ b/src/dan_lab_to_nwb/huang_2025_tdt/reorganize_data.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+from pydantic import FilePath
+
+
+def reorganize_data(data_dir_path: FilePath):
+    data_dir_path = Path(data_dir_path)
+    dataset_folder_names = [
+        "Bing-202504",
+        "WS8-202504",
+    ]
+    for folder_name in dataset_folder_names:
+        dataset_folder = data_dir_path / folder_name
+        for sub_folder in dataset_folder.iterdir():
+            if not sub_folder.is_dir():
+                continue
+            tsq_files = list(sub_folder.glob("*.tsq"))
+            if len(tsq_files) == 0:
+                print(f"No .tsq files were found in {sub_folder.name}, so it is assumed to be already organized.")
+                continue
+            tsq_file = tsq_files[0]
+            session_name = tsq_file.name.split(sub_folder.name)[0].strip("_")
+            session_folder_path = dataset_folder / session_name
+            session_folder_path.mkdir(exist_ok=True)
+            sub_folder.rename(session_folder_path / sub_folder.name)
+
+    # Special case for stand-alone example sessions
+    example_session_dataset_folder = data_dir_path / "ExampleSessions"
+    example_session_dataset_folder.mkdir(exist_ok=True)
+    example_sessions = [
+        "M301-240917-163001",
+        "M301-241108-072001",
+    ]
+    for folder_name in example_sessions:
+        folder_path = data_dir_path / folder_name
+        if not folder_path.is_dir():
+            continue
+
+        tsq_file = list(folder_path.glob("*.tsq"))[0]
+        session_name = tsq_file.name.split(folder_name)[0].strip("_")
+        session_folder_path = example_session_dataset_folder / session_name
+        session_folder_path.mkdir(exist_ok=True)
+        folder_path.rename(session_folder_path / folder_name)
+
+
+def main():
+    data_dir_path = "/Volumes/T7/CatalystNeuro/Dan/Test - TDT data"
+    reorganize_data(data_dir_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dan_lab_to_nwb/huang_2025_tdt/reorganize_data.py
+++ b/src/dan_lab_to_nwb/huang_2025_tdt/reorganize_data.py
@@ -20,9 +20,12 @@ def reorganize_data(data_dir_path: FilePath):
                 continue
             tsq_file = tsq_files[0]
             session_name = tsq_file.name.split(sub_folder.name)[0].strip("_")
-            session_folder_path = dataset_folder / session_name
-            session_folder_path.mkdir(exist_ok=True)
-            sub_folder.rename(session_folder_path / sub_folder.name)
+
+            temp_path = sub_folder.rename(dataset_folder / f"temp_{sub_folder.name}")
+            sub_folder.mkdir()
+            session_folder_path = sub_folder / session_name
+            session_folder_path.mkdir()
+            temp_path.rename(session_folder_path / sub_folder.name)
 
     # Special case for stand-alone example sessions
     example_session_dataset_folder = data_dir_path / "ExampleSessions"
@@ -38,9 +41,12 @@ def reorganize_data(data_dir_path: FilePath):
 
         tsq_file = list(folder_path.glob("*.tsq"))[0]
         session_name = tsq_file.name.split(folder_name)[0].strip("_")
-        session_folder_path = example_session_dataset_folder / session_name
-        session_folder_path.mkdir(exist_ok=True)
-        folder_path.rename(session_folder_path / folder_name)
+
+        sub_folder = example_session_dataset_folder / folder_name
+        sub_folder.mkdir(exist_ok=True)
+        session_folder = sub_folder / session_name
+        session_folder.mkdir(exist_ok=True)
+        folder_path.rename(session_folder / folder_name)
 
 
 def main():


### PR DESCRIPTION
This PR adds Convert All Session scripts for both the TDT and DLC protocols, as well as works through a few edge cases namely:
- skipped sessions that were in the Gdrive but aren't to be included in the final dataset
- control ogen sessions that only have test pulse stim

I also added a reorganized_data.py script that adds some nested folders to the TDT sessions which are required by the TDT interface. 